### PR TITLE
correctly indent wercker.yml

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -3,17 +3,17 @@ build:
   steps:
     - bundle-install
     - script:
-      name: generate site
-      code: bundle exec jekyll build --trace
+       name: generate site
+       code: bundle exec jekyll build --trace
 deploy:
   steps:
     - wercker/add-ssh-key:
-      keyname: SSH_KEY
+        keyname: SSH_KEY
     - add-to-known_hosts:
-      hostname: $REMOTE_HOST
+        hostname: $REMOTE_HOST
     - install-packages:
-      packages: rsync
+        packages: rsync
     - script:
-      name: rsync _site to production server
-      code: |
-        rsync -avz --delete -e ssh _site/ $REMOTE_USER@$REMOTE_HOST:~/blog/
+        name: rsync _site to production server
+        code: |
+          rsync -avz --delete -e ssh _site/ $REMOTE_USER@$REMOTE_HOST:~/blog/


### PR DESCRIPTION
I've fixed the indention. Wercker seems to work again.

```
Hi,

We are investigating an issue with a previously allowed way of indenting giving problems. The solutions on getting things working for you is usually simple, update the indentation. The problem probably lies with the indentation of the properties/parameters for steps. See the following gist for an example: https://gist.github.com/flenter/1a60ff187312d16279ec

Sorry for the inconvenience!

Cheers,
Jacco
```
